### PR TITLE
exclude template files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,6 @@ traefik_validation_excluded_files: []
 # - secret_name: my_secret_api_key
 traefik_manage_secrets: false
 
-
 #hide the service log, e.g. if you can't use secrets anywhere
 traefik_no_service_log: false
 
@@ -28,11 +27,6 @@ traefik_files_location: "files/traefik/"
 traefik_copy_rules: true
 traefik_rules_location: "files/traefik/rules"
 traefik_rules_location_absolute: "{{ playbook_dir }}/{{ traefik_rules_location }}"
-# if using a certresolver for DNS challenge,
-# set to true and put credentials in vault, like
-# traefik_docker_secrets:
-#   cloudflare_api_key: abcdefghijklmnop
-traefik_manage_secrets: false
 
 traefik_update:
   failure_action: rollback
@@ -52,7 +46,6 @@ traefik_rollback:
 hostname: traefik.example.org
 
 traefik_domain: "{{ hostname }}"
-
 
 traefik_networks:
   traefik:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,6 @@ traefik_force_validation: false
 traefik_validation: true
 traefik_validation_image: ghcr.io/otto-de/traefik-config-validator
 
-traefik_validation_excluded_files: []
 # enables the automatic creation of docker swarm secrets
 # you must provide a dictionary in the following way in your vault:
 # traefik_docker_secrets:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ traefik_force_validation: false
 traefik_validation: true
 traefik_validation_image: ghcr.io/otto-de/traefik-config-validator
 
+traefik_validation_excluded_files: []
 # enables the automatic creation of docker swarm secrets
 # you must provide a dictionary in the following way in your vault:
 # traefik_docker_secrets:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
 
   license: CC-BY-4.0
 
-  min_ansible_version: 2.4
+  min_ansible_version: "2.4"
   platforms:
     - name: EL
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,4 +27,3 @@ dependencies:
     vars:
       docker_users:
         - "{{ traefik_user }}"
-

--- a/tasks/healthcheck.yml
+++ b/tasks/healthcheck.yml
@@ -6,7 +6,7 @@
   changed_when: false
 - name: Check for errors
   ansible.builtin.shell:
-    cmd: "docker service ps {{ item.name }} --format '{{ '{{' }} .CurrentState {{ '}}' }}' | awk '{print $1}'| grep Running | wc -l"
+    cmd: "set -o pipefail && docker service ps {{ item.name }} --format '{{ '{{' }} .CurrentState {{ '}}' }}' | awk '{print $1}'| grep Running | wc -l"
   register: inspect
   changed_when: false
 - name: Debugging hint

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
     secrets: "{{ item.secrets | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
     cap_add: "{{ item.cap_add | default(omit) }}"
-  no_log: "{{ traefik_no_service_log}}"
+  no_log: "{{ traefik_no_service_log }}"
   loop:
     "{{ traefik_containers }}"
   notify: service_changed

--- a/tasks/update_secret.yml
+++ b/tasks/update_secret.yml
@@ -15,6 +15,7 @@
       command: "docker service update
         --secret-rm {{ secret.secret_name }}
          {{ service.name }}"
+      changed_when: true
     - name: Delete old secret
       community.docker.docker_secret:
         name: "{{ secret.secret_name }}"
@@ -28,4 +29,5 @@
     - name: Add new secret to service
       command: "docker service update
         --secret-add source={{ secret.secret_name }},target={{ secret.secret_name }}
-         {{ service.name }}"
+        {{ service.name }}"
+      changed_when: true

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -15,6 +15,10 @@
   set_fact:
     traefik_version: "{{ traefik_definition.image.split(':')[1] | regex_replace('^v', '') | default('') }}"
 
+- name: Exclude template files, that can not be validated
+  ansible.builtin.set_fact:
+    __validation_volumes: "{{ lookup('fileglob',traefik_rules_location_absolute + '/*.yml',wantlist=true) | reject('search','template') | list | map('regex_replace', '^(.*)(/[^/]+)$', '\\1/\\2:/traefik\\2') }}"
+
 - name: Validate if traefik version < v3
   when: (traefik_version is version('3', '<') and traefik_validation) or traefik_force_validation
   delegate_to: localhost
@@ -25,8 +29,7 @@
         name: traefik-validator
         command: ["-cfgdir", "/traefik"]
         image: "{{ traefik_validation_image }}"
-        volumes:
-          - "{{ traefik_rules_location_absolute }}:/traefik:ro"
+        volumes: "{{ __validation_volumes }}"
         detach: false
       register: validation
     - name: Remove container

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ traefik_user }}"
     group: "{{ traefik_group }}"
-    mode: '0700'
+    mode: "0700"
 
 - name: Find treafik container in traefik_containers "traefik"
   set_fact:
@@ -37,6 +37,11 @@
         name: traefik-validator
         state: absent
 
+- name: Ensure rsync
+  ansible.builtin.package:
+    name:
+      - rsync
+
 - name: Sync rules files
   ansible.posix.synchronize:
     archive: false
@@ -51,6 +56,6 @@
     dest: "{{ traefik_dir }}/rules"
     owner: "{{ traefik_user }}"
     group: "{{ traefik_group }}"
-    mode: '0700'
+    mode: "0700"
   with_fileglob:
     - "{{ traefik_dir }}/rules/*.yml"

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -17,7 +17,7 @@
 
 - name: Exclude template files, that can not be validated
   ansible.builtin.set_fact:
-    __validation_volumes: "{{ lookup('fileglob',traefik_rules_location_absolute + '/*.yml',wantlist=true) | reject('search','template') | list | map('regex_replace', '^(.*)(/[^/]+)$', '\\1/\\2:/traefik\\2') }}"
+    __validation_volumes: "{{ lookup('fileglob', traefik_rules_location_absolute + '/*.yml', wantlist=true) | reject('search', 'template') | list | map('regex_replace', '^(.*)(/[^/]+)$', '\\1/\\2:/traefik\\2') }}"
 
 - name: Validate if traefik version < v3
   when: (traefik_version is version('3', '<') and traefik_validation) or traefik_force_validation


### PR DESCRIPTION
This excludes traefik rule files from validation `template` is present in the file name.
Go templates can not be validated by [otto-de/traefik-config-validator](https://github.com/otto-de/traefik-config-validator)